### PR TITLE
content: update iOS installation guide

### DIFF
--- a/src/pages/wiki/iOS-自签.md
+++ b/src/pages/wiki/iOS-自签.md
@@ -1,13 +1,13 @@
 ---
 layout: ../../layouts/Post.astro
-title: "iOS 安装教程 (自签)"
+title: "iOS 安装教程 (自签名)"
 ---
 
 # iOS 安装教程
 
 在 iOS 设备上安装 Animeko 需要使用“侧载”（Sideload）工具。本教程将详细介绍两种安装方案：**Sideloadly** 和 **AltStore**。
 
-这两种方法均利用了 Apple 提供的开发者签名功能。对于未付费的用户，存在以下限制：
+这两种方法均利用了 Apple 提供的开发者签名功能。对于未成为 Apple Developer Program 会员的用户，存在以下限制：
 - 应用签名有效期为 7 天，到期后需重新续签，否则应用将无法打开。
 - 单个 Apple ID 最多同时安装 3 个侧载应用。
 


### PR DESCRIPTION
对 iOS 安装教程进行了重构与扩展，主要改动包括：

+ 补充了 iOS 侧载相关限制的说明，帮助用户更好理解安装前提
+ 对 Sideloadly 安装流程进行了整理与润色
+ 新增 AltStore 的安装与使用说明

其中，AltStore 源部分暂时使用了我维护的 [ani-altstore-source](https://github.com/maxchang3/ani-altstore-source)

通过 AltStore Source，可以更方便地在 AltStore / SideStore 中安装和更新应用，效果如下：

| iPad | iPhone |
| - | - |
| ![](https://github.com/user-attachments/assets/bc9e0a38-3487-489e-9f03-3cf7e6563dfe) |  ![](https://github.com/user-attachments/assets/cb49bca7-8c80-4c96-8387-765eeb7ac511) |


[在线预览](https://therealfoxster.github.io/altsource-viewer/view/?source=https://raw.githubusercontent.com/maxchang3/ani-altstore-source/main/generated/apps.json)

当然，目前的方式还有待商榷，关于 AltStore 源的后续方案，目前有两种可能的维护方式，供参考：

- **集成方案**：通过 [Static File Endpoints](https://docs.astro.build/en/guides/endpoints/#static-file-endpoints) 将生成逻辑直接集成到 [ani-website](https://github.com/open-ani/ani-website) 中， 将产物部署至 `https://animeko.org/`，并可配合 webhook，在主仓库 release 时触发自动构建与部署。（下载页面未来或许也可以采用类似的重构思路。）
- **独立方案**： 继续以 [ani-altstore-source](https://github.com/maxchang3/ani-altstore-source) 作为独立项目维护（如合适，可迁移至组织名下）。
- ~~**后端方案**：如果可以在后端添加相关功能。~~

若该部分暂不需要，也可以在本 PR 中移除。相关讨论见：https://github.com/open-ani/animeko/issues/2564

~~文章中的图片链接目前均已失效，仅保留占位，方便后面更新替换。~~

图片链接已经替换