### PR TITLE
✨ refactor(changelogs): migrate to content collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.17.1",
     "danmaku": "^2.0.9",
-    "marked": "^17.0.1",
     "mingcute_icon": "^2.9.71",
     "remark-anchor-link": "^0.1.16",
     "remark-github-blockquote-alert": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       danmaku:
         specifier: ^2.0.9
         version: 2.0.9
-      marked:
-        specifier: ^17.0.1
-        version: 17.0.1
       mingcute_icon:
         specifier: ^2.9.71
         version: 2.9.71
@@ -1586,11 +1583,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  marked@17.0.1:
-    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
-    engines: {node: '>= 20'}
-    hasBin: true
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -3976,8 +3968,6 @@ snapshots:
       source-map-js: 1.2.1
 
   markdown-table@3.0.4: {}
-
-  marked@17.0.1: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,56 @@
+import { defineCollection } from "astro:content";
+import type { Loader } from "astro/loaders";
+import { z } from "astro/zod";
+
+const changelogSchema = z.object({
+  version: z.string(),
+  downloadUrlAlternatives: z.array(z.string()),
+  publishTime: z.coerce.number().transform((ts) => {
+    return new Date(ts * 1000).toISOString().slice(0, 10);
+  }),
+  description: z.string(),
+});
+
+type Changelog = z.infer<typeof changelogSchema>;
+
+const changelogLoader: Loader = {
+  name: "changelog-loader",
+  async load({ renderMarkdown, store, parseData }) {
+    const response = await fetch(
+      "https://danmaku-cn.myani.org/v1/updates/incremental/details?clientVersion=4.0.0&clientPlatform=android&clientArch=x86_64&releaseClass=stable"
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to fetch changelogs");
+    }
+
+    const { updates } = (await response.json()) as { updates: Changelog[] };
+
+    const stableUpdates = updates
+      .toReversed()
+      .filter((update) => !update.version.includes("beta") && !update.version.includes("alpha"));
+
+    store.clear();
+
+    for (const update of stableUpdates) {
+      const parsedData = await parseData({
+        id: update.version,
+        data: update,
+      });
+
+      store.set({
+        id: parsedData.version,
+        data: parsedData,
+        rendered: await renderMarkdown(parsedData.description),
+      });
+    }
+  },
+  schema: changelogSchema,
+};
+
+export const collections = {
+  changelogs: defineCollection({
+    loader: changelogLoader,
+    schema: changelogSchema,
+  }),
+};

--- a/src/pages/changelogs.astro
+++ b/src/pages/changelogs.astro
@@ -1,44 +1,36 @@
 ---
-import { marked } from 'marked'
-import Layout from '@/layouts/Changelog.astro'
-import '@/styles/markdown.css'
+import { getCollection, render } from "astro:content";
+import Layout from "@/layouts/Changelog.astro";
+import "@/styles/markdown.css";
 
-function ts2str(ts: number): string {
-  const date = new Date(ts * 1000)
-  const y = date.getFullYear().toString()
-  const m = (date.getMonth() + 1).toString().padStart(2, '0')
-  const d = date.getDate().toString().padStart(2, '0')
-  return `${y}-${m}-${d}`
-}
-interface dataType {
-  updates: Array<{
-    version: string
-    downloadUrlAlternatives: string[]
-    publishTime: number
-    description: string
-  }>
-}
-
-let html = '';
-
-const response = await fetch(
-  'https://danmaku-cn.myani.org/v1/updates/incremental/details?clientVersion=4.0.0&clientPlatform=android&clientArch=x86_64&releaseClass=stable',
-)
-if(!response){ throw "Error when fetching changelogs." }
-const data: dataType = await response.json()
-const { updates } = data
-html += marked.parse(`# Changelog\n[![GitHub Release](https://img.shields.io/github/v/release/open-ani/animeko?sort=semver&display_name=tag&style=flat-square)](https://github.com/open-ani/animeko/releases/latest)\n\n> 本页面仅展示 v4.x.x 版本的更新日志, 且不包括 Beta 与 Pre-release 版本。`);
-[...updates].reverse().forEach((update) => {
-  if (update.version.includes('beta') || update.version.includes('alpha')) {
-    return
-  }
-  // @ts-ignore
-  html += marked.parse(`## v${update.version} \n\n更新时间: ${ts2str(update.publishTime)}\n\n${update.description}`)
-  html += `\n`
-});
-
+const changelogs = await getCollection("changelogs");
 ---
 
 <Layout>
-  <article class="markdown-body" set:html={html} />
+  <article class="markdown-body">
+    <h1>Changelog</h1>
+    <p>
+      <a href="https://github.com/open-ani/animeko/releases/latest" target="_blank" rel="noopener noreferrer">
+        <img src="https://img.shields.io/github/v/release/open-ani/animeko?sort=semver&display_name=tag&style=flat-square" alt="GitHub Release"/>
+      </a>
+    </p>
+    <blockquote>
+      <p>
+        本页面仅展示 v4.x.x 版本的更新日志, 且不包括 Beta 与 Pre-release 版本。
+      </p>
+    </blockquote>
+
+    {
+      changelogs.map(async (changelog) => {
+        const { Content } = await render(changelog);
+        return (
+          <section>
+            <h2>v{changelog.data.version}</h2>
+            <p>更新时间: {changelog.data.publishTime}</p>
+            <Content />
+          </section>
+        );
+      })
+    }
+  </article>
 </Layout>


### PR DESCRIPTION
使用 Content Collection 重构更新日志
* 优化了整体结构，提高可维护性和扩展性。
* 实现了 Changelog 的 Zod Schema、Content Loader 及 Content Collection。
  * 移除了不必要的 `marked` 依赖，改用 Astro 内置 Markdown 渲染器 ([renderMarkdown](https://docs.astro.build/en/reference/content-loader-reference/#rendermarkdown))，保证渲染一致性、安全性。
  * 使用 Zod Schema 简化了数据转换，增加了数据校验，以增强类型安全。

---

此处 changelog 的 schema、loader、collection 实际上也可以命名为 updates，略作调整后，后面重构下载页面可以复用。