### PR TITLE
docs: rewrite AGENTS.md and update contributing guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,130 +1,81 @@
 # AGENTS.md
 
-This document provides context, conventions, and instructions for AI agents (and human developers) working on the `animeko-website` repository. 
+Compact instructions for AI agents working on `animeko-website` (https://myani.org).
 
-## 1. Project Overview
+## Stack
 
-- **Framework:** [Astro](https://astro.build/) (v5.x)
-- **UI Framework:** [SolidJS](https://solidjs.com/) (v1.x)
-- **Styling:** [Tailwind CSS](https://tailwindcss.com/) (v4.x) using `@tailwindcss/vite`.
-- **Linter/Formatter:** [Biome](https://biomejs.dev/) (v2.x).
-- **Package Manager:** [pnpm](https://pnpm.io/) (v10.x).
-- **Language:** TypeScript (Strict mode enabled).
+- **Framework:** Astro v6 (static output, deployed to Cloudflare Pages via `wrangler.jsonc`)
+- **UI:** SolidJS v1 (JSX in `.tsx` files)
+- **Styling:** Tailwind CSS v4 via `@tailwindcss/vite`
+- **Lint/Format:** Biome v2 — do NOT use Prettier or ESLint
+- **Package Manager:** pnpm v10 (lockfile: `pnpm-lock.yaml`; also has `bun.lock` but use pnpm)
+- **Language:** TypeScript strict mode. Path alias `@/*` → `src/*`
 
-## 2. Development & Build Commands
+## Commands
 
-Always use `pnpm` for script execution.
+```
+pnpm dev              # Dev server
+pnpm build            # astro check + astro build (run before committing)
+pnpm code:fix         # biome check --write . (lint + format fix)
+pnpm test:logic       # node --experimental-strip-types --test src/components/modules/*.test.ts
+pnpm astro check      # Type-check only (also runs as pre-commit on *.astro via lint-staged)
+```
 
-### Core Commands
-- **Start Development Server:**
-  ```bash
-  pnpm dev
-  # or
-  pnpm start
-  ```
-  Runs `astro dev`.
+Verification order: `pnpm code:fix` → `pnpm build` → if UI changed, `pnpm dev` to spot-check.
 
-- **Build Production Artifacts:**
-  ```bash
-  pnpm build
-  ```
-  Runs `astro check` (type checking) followed by `astro build`. 
-  *Note: Always run this before submitting changes to ensure type safety.*
+## Testing
 
-- **Preview Production Build:**
-  ```bash
-  pnpm preview
-  ```
+Logic tests use Node's built-in test runner (`node:test` + `node:assert/strict`). Test files live alongside source as `*.test.ts` in `src/components/modules/`. Run with `pnpm test:logic`.
 
-### Linting & Formatting
-The project uses **Biome** for both linting and formatting. Do not use Prettier or ESLint commands.
+## Content Collections
 
-- **Lint and Fix Code:**
-  ```bash
-  pnpm code:lint
-  ```
-  Executes `biome lint . --fix`.
+Defined in `src/content.config.ts`:
 
-- **Type Checking:**
-  ```bash
-  pnpm astro check
-  ```
-  Checks `.astro` files and TypeScript validity.
+- **changelogs** — custom loader fetches release data from an external API at build time. Schema: `version`, `downloadUrlAlternatives`, `publishTime` (unix seconds → ISO date), `description` (rendered as markdown).
+- **wiki** — glob loader over `src/content/wiki/*.md`. Frontmatter: `title` (required), `order` (optional), `authors` (optional array).
 
-### Testing
-There is currently no dedicated unit test runner (like Vitest) configured in `package.json`.
-**Verification Strategy for Agents:**
-1. **Static Analysis:** Run `pnpm code:lint` to catch syntax and style errors.
-2. **Type Safety:** Run `pnpm build` (which includes `astro check`) to verify type integrity.
-3. **Runtime Verification:** If making UI changes, ensure the dev server starts without errors via `pnpm dev`.
+## Key Source Layout
 
-## 3. Code Style & Conventions
+```
+src/
+  components/
+    common/       # NavBar, Footer, GoogleAnalytics
+    home/         # Landing page sections (Header, Features, FAQ, etc.)
+    modules/      # Interactive components (DownloadList.tsx) + logic tests
+  content/
+    wiki/         # Wiki markdown files
+  config/         # ads.ts
+  layouts/        # Layout, Doc, Post, Changelog
+  pages/          # File-based routes (index, downloads, changelogs, wiki/*, about, 404)
+  plugins/        # rehypeMarkdownImages.ts (custom rehype plugin)
+  scripts/        # Client-side scripts (analytics, image enhancement)
+  styles/         # Global CSS
+```
 
-Strictly adhere to the rules defined in `biome.json`.
+## Code Style (enforced by biome.json)
 
-### Formatting Rules
-- **Indentation:** 2 spaces.
-- **Line Width:** 120 characters.
-- **Line Endings:** LF.
-- **Quotes:** Double quotes (`"`) for both JS/TS and JSX/Astro attributes.
-- **Semicolons:** Always include semicolons.
-- **Trailing Commas:** ES5 compatible (objects, arrays, etc.).
-- **Arrow Parentheses:** Always included (e.g., `(arg) => ...`).
-- **Bracket Spacing:** `true` (e.g., `{ foo }`).
+- 2-space indent, 120 char line width, LF line endings, double quotes, semicolons always, ES5 trailing commas
+- Arrow parens always, bracket spacing true
+- `organizeImports` enabled; remove unused imports
+- `noNonNullAssertion` is OFF (allowed but use sparingly)
+- Biome rules are relaxed for `.astro`, `.svelte`, `.vue` files (unused vars/imports off)
 
-### Naming Conventions
-- **Components:** PascalCase (e.g., `MyComponent.vue`, `Header.astro`).
-- **Files/Directories:** Kebab-case is generally preferred for pages and assets, though component files usually match the component name.
-- **Variables/Functions:** camelCase.
-- **Constants:** UPPER_CASE or camelCase depending on context.
+## Deployment
 
-### TypeScript
-- **Strict Mode:** Enabled via `astro/tsconfigs/strict`.
-- **No `any`:** Avoid `any` types. Use proper interfaces or `unknown` if necessary.
-- **Non-null Assertions:** Biome rule `noNonNullAssertion` is disabled ("off"), but use them sparingly.
-- **Unused Variables:** specific Biome rules (`noUnusedVariables`) are set to "warn" or "error". Clean up unused code.
+Cloudflare Pages static asset hosting. `wrangler.jsonc` points to `./dist` with auto-trailing-slash HTML handling. CI (`pr_check.yml`) runs on PRs: pnpm install → `pnpm build` with Node 23.x and `--max_old_space_size=8192`.
 
-### CSS / Tailwind
-- **Tailwind v4:** This project uses Tailwind CSS v4.
-- **Directives:** `@apply`, `@theme`, and other Tailwind directives are supported.
-- **Ordering:** Biome handles class sorting/attribute positioning automatically ("auto").
+## Environment
 
-### Imports
-- **Organization:** Biome `organizeImports` is enabled.
-- **Unused Imports:** `noUnusedImports` is set to "warn". Remove them.
-- **File Extensions:** Use explicit extensions where appropriate in ESM, though standard bundler resolution applies.
+Only one env var in `.env.example`: `PUBLIC_GA_MEASUREMENT_ID` (Google Analytics). No other secrets needed for local dev.
 
-## 4. Directory Structure
+## Pre-commit Hooks
 
-- `src/pages/`: Astro file-based routing.
-- `src/components/`: Reusable UI components (Astro or Vue).
-- `src/layouts/`: Astro layouts (e.g., BaseLayout).
-- `src/styles/`: Global styles (CSS/Tailwind).
-- `src/ui/`: Likely atomic or design-system specific UI components.
-- `src/types/`: TypeScript type definitions.
-- `public/`: Static assets served at root.
+`husky` + `lint-staged`: runs `astro check` on `*.astro` files and `biome check` on all staged files. Do not bypass or disable.
 
-## 5. Error Handling
+## Agent Rules
 
-- **Async/Await:** Prefer `async/await` over raw promises.
-- **Try/Catch:** Use standard try/catch blocks for API calls or risky operations.
-- **Console Logs:** Avoid committing `console.log` statements. Use proper logging if available, or remove debug logs before finalizing.
-
-## 6. Git & CI Workflow
-
-- **Pre-commit:** `husky` and `lint-staged` are configured.
-    - `*.astro`: Runs `astro check`.
-- **CI Pipeline:** GitHub Actions (`pr_prew.yml`) runs on Pull Requests.
-    - Installs dependencies with `pnpm`.
-    - Runs `pnpm build`.
-    - Environment: Node.js 23.x.
-
-## 7. Agent Behavior Guidelines
-
-- **File Modification:** When editing files, always read the file first to preserve existing structure.
-- **Dependencies:** Do NOT add new dependencies without explicit instruction. Use existing packages (`@headlessui/vue`, `@iconify/vue`, etc.).
-- **Astro Components:** Keep frontmatter (JavaScript fence `---`) clean and typed.
-- **Safety:** Do not bypass `lint-staged` hooks. Ensure your code passes `pnpm code:lint` and `pnpm build` before marking a task as complete.
-
----
-*Generated for AI Agents interacting with the animeko-website repository.*
+- Do NOT add new dependencies without explicit instruction.
+- Do NOT commit `console.log` statements.
+- Read files before editing to preserve structure.
+- Content is bilingual (English + Chinese). See `README_CN.md` and `CONTRIBUTING_CN.md`.
+- The project has OpenCode skills in `.opencode/skills/` for UI baseline, accessibility, metadata, and motion performance — load relevant skills when those topics apply.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,33 @@
 
 This guide describes how to contribute to the Animeko website.
 
+## Stack
+
+- Framework: Astro v6 (static output, deployed to Cloudflare Pages)
+- UI: SolidJS v1 (JSX in `.tsx` files)
+- Styling: Tailwind CSS v4 via `@tailwindcss/vite`
+- Lint/Format: Biome v2 — do NOT use Prettier or ESLint
+- Package Manager: pnpm v10
+- Language: TypeScript strict mode. Path alias `@/*` → `src/*`
+
 ## Project Structure
 
-- `src/pages/`: File-based routing for Astro pages.
-- `src/components/`: Reusable UI components (Astro or Solid).
-- `src/layouts/`: Shared page layouts.
-- `src/styles/`: Global styles and Tailwind layers.
-- `src/ui/`: Design-system style UI building blocks.
-- `src/types/`: Shared TypeScript types.
-- `public/`: Static assets served at site root.
+```
+src/
+  components/
+    common/       # NavBar, Footer, GoogleAnalytics
+    home/         # Landing page sections (Header, Features, FAQ, etc.)
+    modules/      # Interactive components (DownloadList.tsx) + logic tests
+  content/
+    wiki/         # Wiki markdown files
+  config/         # ads.ts
+  layouts/        # Layout, Doc, Post, Changelog
+  pages/          # File-based routes (index, downloads, changelogs, wiki/*, about, 404)
+  plugins/        # rehypeMarkdownImages.ts (custom rehype plugin)
+  scripts/        # Client-side scripts (analytics, image enhancement)
+  styles/         # Global CSS
+public/           # Static assets served at site root
+```
 
 ## Development Environment
 
@@ -33,25 +51,47 @@ pnpm dev
 
 The site runs at `http://localhost:4321` by default. Use `pnpm start` as an alias for `pnpm dev`.
 
+## Available Commands
+
+```
+pnpm dev              # Dev server
+pnpm build            # astro check + astro build (run before committing)
+pnpm code:fix         # biome check --write . (lint + format fix)
+pnpm test:logic       # node --experimental-strip-types --test src/components/modules/*.test.ts
+pnpm astro check      # Type-check only (also runs as pre-commit on *.astro via lint-staged)
+```
+
 ## Code Standards
 
 - Use TypeScript (strict mode is enabled).
-- Follow Biome formatting and linting rules in `biome.json`.
+- Follow Biome formatting and linting rules in `biome.json` (2-space indent, 120 char line width, double quotes, semicolons, ES5 trailing commas).
 - Use Tailwind CSS v4 for styling.
 - Keep imports organized and remove unused code.
+
+## Testing
+
+Logic tests use Node's built-in test runner (`node:test` + `node:assert/strict`). Test files live alongside source as `*.test.ts` in `src/components/modules/`. Run with `pnpm test:logic`.
 
 ## Commit Standards
 
 - Use concise, descriptive commit messages.
 - Gitmoji is recommended: <https://gitmoji.dev/>
 
+## Pre-commit Hooks
+
+`husky` + `lint-staged` run automatically on commit:
+- `astro check` on `*.astro` files
+- `biome check` on all staged files
+
+Do not bypass or disable these hooks.
+
 ## Code Quality Requirements
 
-Run these before submitting:
+Verification order before submitting:
 
 ```bash
 pnpm code:fix
 pnpm build
 ```
 
-`pnpm build` includes type checking via `astro check`.
+If you changed UI, also run `pnpm dev` to spot-check. `pnpm build` includes type checking via `astro check`.

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -2,15 +2,33 @@
 
 本指南用于说明如何为 Animeko 网站做贡献。
 
+## 技术栈
+
+- 框架：Astro v6（静态输出，部署到 Cloudflare Pages）
+- UI：SolidJS v1（JSX 写在 `.tsx` 文件中）
+- 样式：Tailwind CSS v4，通过 `@tailwindcss/vite` 集成
+- Lint/格式化：Biome v2 — 请勿使用 Prettier 或 ESLint
+- 包管理器：pnpm v10
+- 语言：TypeScript 严格模式。路径别名 `@/*` → `src/*`
+
 ## 项目结构
 
-- `src/pages/`: Astro 页面路由目录。
-- `src/components/`: 可复用 UI 组件（Astro 或 Solid）。
-- `src/layouts/`: 页面布局。
-- `src/styles/`: 全局样式与 Tailwind 层。
-- `src/ui/`: 设计系统风格的基础组件。
-- `src/types/`: 共享 TypeScript 类型。
-- `public/`: 站点根目录静态资源。
+```
+src/
+  components/
+    common/       # NavBar、Footer、GoogleAnalytics
+    home/         # 落地页各区块（Header、Features、FAQ 等）
+    modules/      # 交互组件（DownloadList.tsx）+ 逻辑测试
+  content/
+    wiki/         # Wiki Markdown 文件
+  config/         # ads.ts
+  layouts/        # Layout、Doc、Post、Changelog
+  pages/          # 基于文件的路由（index、downloads、changelogs、wiki/*、about、404）
+  plugins/        # rehypeMarkdownImages.ts（自定义 rehype 插件）
+  scripts/        # 客户端脚本（统计、图片增强）
+  styles/         # 全局 CSS
+public/           # 站点根目录静态资源
+```
 
 ## 开发环境要求
 
@@ -33,25 +51,47 @@ pnpm dev
 
 默认访问地址为 `http://localhost:4321`。`pnpm start` 作为 `pnpm dev` 的别名。
 
+## 可用命令
+
+```
+pnpm dev              # 开发服务器
+pnpm build            # astro check + astro build（提交前执行）
+pnpm code:fix         # biome check --write .（lint + 格式化修复）
+pnpm test:logic       # node --experimental-strip-types --test src/components/modules/*.test.ts
+pnpm astro check      # 仅类型检查（也会在 pre-commit 阶段对 *.astro 文件运行）
+```
+
 ## 代码规范
 
 - 使用 TypeScript（严格模式已开启）。
-- 遵循 `biome.json` 中的格式化与 lint 规则。
+- 遵循 `biome.json` 中的格式化与 lint 规则（2 空格缩进、120 字符行宽、双引号、分号、ES5 尾逗号）。
 - 样式使用 Tailwind CSS v4。
 - 保持 import 有序，移除未使用代码。
+
+## 测试
+
+逻辑测试使用 Node 内置测试运行器（`node:test` + `node:assert/strict`）。测试文件以 `*.test.ts` 的形式放在 `src/components/modules/` 源码旁边。使用 `pnpm test:logic` 运行。
 
 ## 提交规范
 
 - 提交信息简洁清晰。
 - 推荐使用 Gitmoji：<https://gitmoji.dev/>
 
+## Pre-commit 钩子
+
+`husky` + `lint-staged` 会在提交时自动运行：
+- 对 `*.astro` 文件运行 `astro check`
+- 对所有暂存文件运行 `biome check`
+
+请勿绕过或禁用这些钩子。
+
 ## 代码质量要求
 
-提交前请执行：
+提交前请按以下顺序验证：
 
 ```bash
 pnpm code:fix
 pnpm build
 ```
 
-`pnpm build` 会包含 `astro check` 的类型检查。
+如果修改了 UI，请额外执行 `pnpm dev` 进行预览检查。`pnpm build` 会包含 `astro check` 的类型检查。


### PR DESCRIPTION
Split from #53. Documentation changes only.

- Major rewrite of `AGENTS.md` to be more concise and actionable for AI agents
- Updated `CONTRIBUTING.md` and `CONTRIBUTING_CN.md` with clearer stack descriptions, detailed project structure, available commands, code standards, testing instructions, and pre-commit hooks