### PR TITLE
feat: add windows arm64 download entry

### DIFF
--- a/src/components/modules/DownloadList.tsx
+++ b/src/components/modules/DownloadList.tsx
@@ -12,6 +12,7 @@ import {
 const PLAT_TYPE: Record<string, string> = {
   "android-universal": "安卓 APK",
   "windows-x86_64": "Windows",
+  "windows-aarch64": "Windows (ARM64)",
   "macos-aarch64": "macOS (M系列芯片)",
   "macos-x86_64": "macOS (Intel 芯片)",
   "linux-x86_64": "Linux AppImage",
@@ -21,6 +22,7 @@ const PLAT_TYPE: Record<string, string> = {
 const PLATFORM_ICONS: Record<string, string> = {
   "android-universal": "mgc_android_line",
   "windows-x86_64": "mgc_windows_line",
+  "windows-aarch64": "mgc_windows_line",
   "macos-aarch64": "mgc_apple_line",
   "macos-x86_64": "mgc_apple_line",
   "linux-x86_64": "mgc_linux_line",
@@ -30,6 +32,7 @@ const PLATFORM_ICONS: Record<string, string> = {
 const GUIDANCE_LINK: Record<string, string> = {
   "android-universal": "",
   "windows-x86_64": "",
+  "windows-aarch64": "",
   "macos-aarch64": "",
   "linux-x86_64": "/wiki/linux-install",
   "ios-aarch64": "/wiki/ios-install",


### PR DESCRIPTION
The update API already returns `windows-aarch64` download links, but the
page never showed them.

## 概述

`ReleaseCard` renders links generically from
`data.downloadUrlAlternativesMap[releaseKey]`, but which rows exist is
decided by `Object.keys(PLAT_TYPE)` — not by the API response. Registering
the key is all that is needed.

## 改动

- `PLAT_TYPE`: `windows-aarch64` → `Windows (ARM64)`
- `PLATFORM_ICONS`: reuses `mgc_windows_line`
- `GUIDANCE_LINK`: empty, same as x64 — no install guide exists yet

The x64 row keeps its plain `Windows` label: it is the default most
visitors want, and the `(ARM64)` suffix is the signal the minority needs to
claim its own row.

## 验证

Ran `astro dev` and rendered `/downloads`. Note the update API returns 403
for requests carrying a `localhost` Origin, so the page cannot load real
data locally; verified against a temporary local mock instead. The new row
appears between Windows and macOS with the correct icon, and both the
primary and mirror links render.
